### PR TITLE
fix QScrollBar swapped horizontal scroll buttons

### DIFF
--- a/qdarkstyle/style.qss
+++ b/qdarkstyle/style.qss
@@ -187,7 +187,7 @@ QScrollBar::handle:horizontal
     border-radius: 5px;
 }
 
-QScrollBar::sub-line:horizontal
+QScrollBar::add-line:horizontal
 {
     border-image: url(:/qss_icons/rc/right_arrow_disabled.png);
     width: 10px;
@@ -196,7 +196,7 @@ QScrollBar::sub-line:horizontal
     subcontrol-origin: margin;
 }
 
-QScrollBar::add-line:horizontal
+QScrollBar::sub-line:horizontal
 {
     border-image: url(:/qss_icons/rc/left_arrow_disabled.png);
     height: 10px;
@@ -205,7 +205,7 @@ QScrollBar::add-line:horizontal
     subcontrol-origin: margin;
 }
 
-QScrollBar::sub-line:horizontal:hover,QScrollBar::sub-line:horizontal:on
+QScrollBar::add-line:horizontal:hover,QScrollBar::add-line:horizontal:on
 {
     border-image: url(:/qss_icons/rc/right_arrow.png);
     height: 10px;
@@ -215,7 +215,7 @@ QScrollBar::sub-line:horizontal:hover,QScrollBar::sub-line:horizontal:on
 }
 
 
-QScrollBar::add-line:horizontal:hover, QScrollBar::add-line:horizontal:on
+QScrollBar::sub-line:horizontal:hover, QScrollBar::sub-line:horizontal:on
 {
     border-image: url(:/qss_icons/rc/left_arrow.png);
     height: 10px;


### PR DESCRIPTION
QScrollBar::add-line:horizontal and QScrollBar::sub-line:horizontal were swapped in the style sheet, causing the left/right scroll buttons to scroll in the opposite directions
