### PR TITLE
fixed README C++ example

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ else
 {
     f.open(QFile::ReadOnly | QFile::Text);
     QTextStream ts(&f);
-    QApplication::instance()->setStyleSheet(ts.readAll());
+    qApp->setStyleSheet(ts.readAll());
 }
 
 ```


### PR DESCRIPTION
Problem:
QApplication::instance() returns a QCoreApplication, which does not have the setStyleSheet method, causing error.

Fix:
Replace QApplication::instance() for qApp macro (that will return the instace of QApplication in use).