### PR TITLE
Fixes for vertical QToolBar, QToolBar Extend Button & QTabWidget's Pane Misalignment

### DIFF
--- a/qdarkstyle/style.qss
+++ b/qdarkstyle/style.qss
@@ -582,6 +582,9 @@ QToolBar::separator:horizontal {
 QToolBar::separator:vertical {
     image: url(:/qss_icons/rc/Vsepartoolbar.png);
 }
+QToolButton#qt_toolbar_ext_button {
+    background: #58595a
+}
 
 QPushButton
 {

--- a/qdarkstyle/style.qss
+++ b/qdarkstyle/style.qss
@@ -742,7 +742,7 @@ QTabWidget{
 QTabWidget::pane {
     border: 1px solid #76797C;
     padding: 5px;
-    margin: 1px;
+    margin: 0px;
 }
 
 QTabBar

--- a/qdarkstyle/style.qss
+++ b/qdarkstyle/style.qss
@@ -580,7 +580,7 @@ QToolBar::separator:horizontal {
     image: url(:/qss_icons/rc/Hsepartoolbar.png);
 }
 QToolBar::separator:vertical {
-    image: url(:/qss_icons/rc/Vsepartoolbars.png);
+    image: url(:/qss_icons/rc/Vsepartoolbar.png);
 }
 
 QPushButton


### PR DESCRIPTION
This PR has three fixes,
- Minor naming mistake of the vertical QToolBar's seperator
- Add styling for QToolBar's extend button, which appears when there is not enough space to show all the icons
- Fixes a misalignment between QTabWidget's Pane and QTabBar that made it look like ![screenshot](https://cloud.githubusercontent.com/assets/426027/20068778/f62a2f60-a53f-11e6-81d6-7cde995d3073.jpg)

