### PR TITLE
Removed QLineEdit padding inside QAbstractItemView

### DIFF
--- a/qdarkstyle/style.qss
+++ b/qdarkstyle/style.qss
@@ -325,7 +325,7 @@ QTabWidget:focus, QCheckBox:focus, QRadioButton:focus, QSlider:focus
 QLineEdit
 {
     background-color: #232629;
-    padding: 0px 5px;
+    padding: 5px;
     border-style: solid;
     border: 1px solid #76797C;
     border-radius: 2px;

--- a/qdarkstyle/style.qss
+++ b/qdarkstyle/style.qss
@@ -325,7 +325,7 @@ QTabWidget:focus, QCheckBox:focus, QRadioButton:focus, QSlider:focus
 QLineEdit
 {
     background-color: #232629;
-    padding: 5px;
+    padding: 0px 5px;
     border-style: solid;
     border: 1px solid #76797C;
     border-radius: 2px;


### PR DESCRIPTION
Let me start off by saying I absolutely love this theme!

Unfortunately, I noticed that the text was being cut off vertically while editing items inside my QListView (it may occur with other views/widgets, too), removing the top/bottom padding for QLineEdit seems to have fixed the issue. I don't know enough about QtStylesheets to determine whether there might be a better solution (which doesn't remove the padding for "regular" LineEdits, too).

P.S.: I'm using Qt5 on Win8.1 with C++

Edit: I made a quick & dirty image: http://imgur.com/NYWCs3C
Edit2: I think I found a better solution (sorry for the mess with all the commits, this is my first attempt at contributing and I hope I managed to somehow do it correctly)