### PR TITLE
Able to get Qt info from environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,9 @@ deb_dist
 # hackedit project files
 .hackedit
 
+# vs code project files
+.vscode
+.mypy_cache
+.cache
+.env
+

--- a/README.md
+++ b/README.md
@@ -73,47 +73,100 @@ import sys
 import qdarkstyle
 from PySide import QtGui
 
-
 # create the application and the main window
 app = QtGui.QApplication(sys.argv)
 window = QtGui.QMainWindow()
 
 # setup stylesheet
-app.setStyleSheet(qdarkstyle.load_stylesheet())
+app.setStyleSheet(qdarkstyle.load_stylesheet_pyside())
 
 # run
 window.show()
 app.exec_()
 ```
 
-To use PyQt4 instead of PySide, you just need to replace
+To use another wrapper for Qt, you just need to replace some lines. See examples bellow.
 
-```Python
-app.setStyleSheet(qdarkstyle.load_stylesheet())
-```
+To use PyQt4, change two lines:
 
-by
-
-```Python
-app.setStyleSheet(qdarkstyle.load_stylesheet(pyside=False))
-```
-
-and
 ```Python
 from PySide import QtGui
+app.setStyleSheet(qdarkstyle.load_stylesheet_pyqt())
 ```
 
-by
+If PyQt5, more lines need to be changed because of its API, see the complete example
 
 ```Python
-from PyQt4 import QtGui
-```
+import sys
+import qdarkstyle
+from PyQt5 import QtWidgets
 
-To use PyQt5, you need to use ``load_stylesheet_pyqt5`` instead of
-``load_stylesheet``.
+# create the application and the main window
+app = QtWidgets.QApplication(sys.argv)
+window = QtWidgets.QMainWindow()
 
-```Python
+# setup stylesheet
 app.setStyleSheet(qdarkstyle.load_stylesheet_pyqt5())
+
+# run
+window.show()
+app.exec_()
+```
+
+If your project uses QtPy or you need to set it programmatically, it is far more simple:
+
+```Python
+
+import sys
+import qdarkstyle
+import os
+
+# set the environment variable to use a specific wrapper
+# it can be set to pyqt, pyqt5, pyside or pyside2 (not implemented yet)
+# you do not need to use QtPy to set this variable
+os.environ['QT_API'] = 'pyqt'
+
+# import from QtPy instead of doing it directly
+# note that QtPy always uses PyQt5 API
+from qtpy import QtWidgets
+
+# create the application and the main window
+app = QtWidgets.QApplication(sys.argv)
+window = QtWidgets.QMainWindow()
+
+# setup stylesheet
+app.setStyleSheet(qdarkstyle.load_stylesheet_from_environment())
+
+# run
+window.show()
+app.exec_()
+```
+
+It is also simple if you use PyQtGraph:
+
+```Python
+import sys
+import qdarkstyle
+import os
+
+# set the environment variable to use a specific wrapper
+# it can be set to PyQt, PyQt5, PySide or PySide2 (not implemented yet)
+os.environ['PYQTGRAPH_QT_LIB'] = 'PyQt' 
+
+# import from pyqtgraph instead of doing it directly
+# note that PyQtGraph always uses PyQt4 API
+from pyqtgraph.Qt import QtGui
+
+# create the application and the main window
+app = QtGui.QApplication(sys.argv)
+window = QtGui.QMainWindow()
+
+# setup stylesheet
+app.setStyleSheet(qdarkstyle.load_stylesheet_from_environment(is_pyqtgraph=True))
+
+# run
+window.show()
+app.exec_()
 ```
 
 _There is an example included in the *example* folder.
@@ -129,6 +182,8 @@ request.
 
 Changelog
 =========
+* 2.4:
+    - Add function to get Qt information from environment variable
 
 * 2.3.1:
     - Improve checkbox color (use accent color used in other widgets) and darken view hover/selected colors to play nicer with other widget colors

--- a/qdarkstyle/__init__.py
+++ b/qdarkstyle/__init__.py
@@ -136,7 +136,7 @@ def load_stylesheet_from_environment(is_pyqtgraph=False):
 
     # Just a warning if both are set but differs each other
     if qt_api and pyqtgraph_qt_lib:
-        if qt_api != pyqtgraph_qt_lib:
+        if qt_api != pyqtgraph_qt_lib.lower():
             _logger().warning("Both QT_API=%s and PYQTGRAPH_QT_LIB=%s are set, "
                               "but with different values, this could cause "
                               "some issues if using them in the same project!"

--- a/qdarkstyle/__init__.py
+++ b/qdarkstyle/__init__.py
@@ -30,18 +30,124 @@ with the correct rc file.
 """
 import logging
 import platform
+import os
 
 
-__version__ = "2.3.1"
+__version__ = "2.4"
+
+PYQTGRAPH_QT_LIB_VALUES = ['PyQt', 'PyQt5', 'PySide', 'PySide2']
+QT_API_VALUES = ['pyqt', 'pyqt5', 'pyside', 'pyside2']
 
 
 def _logger():
     return logging.getLogger('qdarkstyle')
 
 
+def _qt_wrapper_import(qt_api):
+    """
+    Check if Qt API defined can be imported.
+
+    :param qt_api: Qt API string to test import
+
+    :return load function fot given qt_api, otherwise empty string
+
+    """
+    qt_wrapper = ''
+    loader = ""
+
+    try:
+        if qt_api == 'PyQt' or qt_api == 'pyqt':
+            import PyQt4
+            qt_wrapper = 'PyQt4'
+            loader = load_stylesheet_pyqt()
+        elif qt_api == 'PyQt5' or qt_api == 'pyqt5':
+            import PyQt5
+            qt_wrapper = 'PyQt5'
+            loader = load_stylesheet_pyqt5()
+        elif qt_api == 'PySide' or qt_api == 'pyside':
+            import PySide
+            qt_wrapper = 'PySide'
+            loader = load_stylesheet_pyside()
+        elif qt_api == 'PySide2' or qt_api == 'pyside2':
+            import PySide2
+            qt_wrapper = 'PySide2'
+            loader = load_stylesheet_pyside2()
+    except ImportError as err:
+        _logger().error("Impossible import Qt wrapper. " + str(err))
+    else:
+        _logger().info("Using Qt wrapper = %s " % qt_wrapper)
+    finally:
+        return loader
+
+
+def load_stylesheet_from_environment(is_pyqtgraph=False):
+    """
+    Load the stylesheet from QT_API (or PYQTGRAPH_QT_LIB) environment variable.
+
+    :param is_pyqtgraph: True if it is to be set using PYQTGRAPH_QT_LIB
+
+    :raise KeyError: if QT_API/PYQTGRAPH_QT_LIB does not exist
+
+    :return the stylesheet string
+    """
+    qt_api = ''
+    pyqtgraph_qt_lib = ''
+
+    loader = ""
+
+    # Get values from QT_API
+    try:
+        qt_api = os.environ['QT_API']
+    except KeyError as err:
+        # Log this error just if using QT_API
+        if not is_pyqtgraph:
+            _logger().error("QT_API does not exist, do os.environ['QT_API']= "
+                            "and choose one option from %s" % QT_API_VALUES)
+    else:
+        if not is_pyqtgraph:
+            if qt_api in QT_API_VALUES:
+                _logger().info("Found QT_API='%s'" % qt_api)
+                loader = _qt_wrapper_import(qt_api)
+            else:
+                # Raise this error because the function need this key/value
+                raise KeyError("QT_API=%s is unknown, please use a value "
+                               "from %s" % (qt_api, QT_API_VALUES))
+
+    # Get values from PYQTGRAPH_QT_LIB
+    try:
+        pyqtgraph_qt_lib = os.environ['PYQTGRAPH_QT_LIB']
+    except KeyError as err:
+        # Log this error just if using PYQTGRAPH_QT_LIB
+        if is_pyqtgraph:
+            _logger().error("PYQTGRAP_QT_API does not exist, do "
+                            "os.environ['PYQTGRAPH_QT_LIB']= "
+                            "and choose one option from %s" %
+                            PYQTGRAPH_QT_LIB_VALUES)
+    else:
+        if is_pyqtgraph:
+            if pyqtgraph_qt_lib in PYQTGRAPH_QT_LIB_VALUES:
+                _logger().info("Found PYQTGRAPH_QT_LIB='%s'" % pyqtgraph_qt_lib)
+                loader = _qt_wrapper_import(pyqtgraph_qt_lib)
+            else:
+                # Raise this error because the function need this key/value
+                raise KeyError("PYQTGRAPH_QT_LIB=%s is unknown, please use a "
+                               "value from %s" % (pyqtgraph_qt_lib,
+                                                  PYQTGRAPH_QT_LIB_VALUES))
+
+    # Just a warning if both are set but differs each other
+    if qt_api and pyqtgraph_qt_lib:
+        if qt_api != pyqtgraph_qt_lib:
+            _logger().warning("Both QT_API=%s and PYQTGRAPH_QT_LIB=%s are set, "
+                              "but with different values, this could cause "
+                              "some issues if using them in the same project!"
+                              % (qt_api, pyqtgraph_qt_lib))
+
+    return loader
+
+
 def load_stylesheet(pyside=True):
     """
-    Loads the stylesheet. Takes care of importing the rc module.
+    Load the stylesheet. Takes care of importing the rc module.
 
     :param pyside: True to load the pyside rc file, False to load the PyQt rc file
 
@@ -81,9 +187,36 @@ def load_stylesheet(pyside=True):
         return stylesheet
 
 
+def load_stylesheet_pyside():
+    """
+    Load the stylesheet for use in a pyside application.
+
+    :return the stylesheet string
+    """
+    return load_stylesheet(pyside=True)
+
+
+def load_stylesheet_pyside2():
+    """
+    Load the stylesheet for use in a pyside2 application.
+
+    :raise NotImplementedError: Because it is not supported yet
+    """
+    raise NotImplementedError("PySide 2 is not supported yet.")
+
+
+def load_stylesheet_pyqt():
+    """
+    Load the stylesheet for use in a pyqt4 application.
+
+    :return the stylesheet string
+    """
+    return load_stylesheet(pyside=False)
+
+
 def load_stylesheet_pyqt5():
     """
-    Loads the stylesheet for use in a pyqt5 application.
+    Load the stylesheet for use in a pyqt5 application.
 
     :param pyside: True to load the pyside rc file, False to load the PyQt rc file
 


### PR DESCRIPTION
- Add a function that get QT_API or PYQTGRAPH_QT_LIB and returns the right load_stylesheet function. It raises KeyError if not found. 
- Add functions with names load_stylesheet_[pyside, pyside2, pyqt, pyqt5] to simplifly.
- Messages with proper errors, warnings and infos are logged.
- Change to imperative mode the first sentence in docstring as recommended by pycodestyle.
- Correct PyQt5 example
- Add QtPy example
- Add PyQtGraph example
- Fix comparison between QT_API and PYQTGRAPH_QT_LIB