### PR TITLE
Improve QPushButton menu arrow margin, fix #102

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -19,6 +19,7 @@ These people contribute to bug fixes, improvements and so on.
 Please, insert your information after the last one.
 
 - Year - Name - `<contact>` - contribution.
+- 2018 - [mowoolli](https://github.com/mowoolli) - bug fixes.
 - 2018 - Xingyun Wu - `xingyun.wu@foxmail.com` - bug fixes.
 - 2018 - [KcHNST](https://github.com/KcHNST) - bug fixes.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changelog
 - 2.6.0
   - PySide 2 (Technical Preview) Support
+  - Improve menu indicator position on QPushButton, #102
 - 2.5.4
   - Fix indicator image of checkable QGroupBox for check/uncheck states, #93 
   - Fix wrong comma position, #95

--- a/qdarkstyle/style.qss
+++ b/qdarkstyle/style.qss
@@ -1065,7 +1065,7 @@ QToolButton::menu-arrow:open {
 QPushButton::menu-indicator {
     subcontrol-origin: padding;
     subcontrol-position: bottom right;
-    left: 8px;
+    bottom: 5px;
 }
 
 QTableView {


### PR DESCRIPTION
There was a left margin of 8px on the menu-indicator. I removed that and put in a bottom margin of 5px. I chose 5px to be consistent with the 5px padding put on QPushButton text. Screenshot of fix and original:

![newmargin](https://user-images.githubusercontent.com/20524201/45923367-1700c400-be99-11e8-9eef-cd6a13798c79.png)

![oldmargin](https://user-images.githubusercontent.com/20524201/45923365-10724c80-be99-11e8-820f-e830fd72eaa1.png)
