### PR TITLE
PR: Fix resources

### DIFF
--- a/qdarkstyle/qss/_styles.scss
+++ b/qdarkstyle/qss/_styles.scss
@@ -693,9 +693,10 @@ https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qsizegrip
 
 --------------------------------------------------------------------------- */
 QSizeGrip {
-    image: url($PATH_RESOURCES + '/rc/sizegrip.png');
+    background: transparent;
     width: 12px;
     height: 12px;
+    image: url($PATH_RESOURCES + '/rc/sizegrip.png');
 }
 
 /* QStackedWidget ---------------------------------------------------------

--- a/qdarkstyle/style.qrc
+++ b/qdarkstyle/style.qrc
@@ -1,44 +1,60 @@
 <RCC>
   <qresource prefix="qss_icons">
-    <file>rc/up_arrow_disabled.png</file>
     <file>rc/Hmovetoolbar.png</file>
-    <file>rc/stylesheet-branch-end.png</file>
+    <file>rc/Hsepartoolbar.png</file>
+    <file>rc/Vmovetoolbar.png</file>
+    <file>rc/Vsepartoolbar.png</file>
     <file>rc/branch_closed-on.png</file>
-    <file>rc/stylesheet-vline.png</file>
     <file>rc/branch_closed.png</file>
     <file>rc/branch_open-on.png</file>
-    <file>rc/transparent.png</file>
-    <file>rc/right_arrow_disabled.png</file>
-    <file>rc/sizegrip.png</file>
-    <file>rc/close.png</file>
+    <file>rc/branch_open.png</file>
+    <file>rc/checkbox_checked.png</file>
+    <file>rc/checkbox_checked@2x.png</file>
+    <file>rc/checkbox_checked_disabled.png</file>
+    <file>rc/checkbox_checked_disabled@2x.png</file>
+    <file>rc/checkbox_checked_focus.png</file>
+    <file>rc/checkbox_checked_focus@2x.png</file>
+    <file>rc/checkbox_indeterminate.png</file>
+    <file>rc/checkbox_indeterminate@2x.png</file>
+    <file>rc/checkbox_indeterminate_disabled.png</file>
+    <file>rc/checkbox_indeterminate_disabled@2x.png</file>
+    <file>rc/checkbox_indeterminate_focus.png</file>
+    <file>rc/checkbox_indeterminate_focus@2x.png</file>
+    <file>rc/checkbox_unchecked.png</file>
+    <file>rc/checkbox_unchecked@2x.png</file>
+    <file>rc/checkbox_unchecked_disabled.png</file>
+    <file>rc/checkbox_unchecked_disabled@2x.png</file>
+    <file>rc/checkbox_unchecked_focus.png</file>
+    <file>rc/checkbox_unchecked_focus@2x.png</file>
     <file>rc/close-hover.png</file>
     <file>rc/close-pressed.png</file>
+    <file>rc/close.png</file>
     <file>rc/down_arrow.png</file>
-    <file>rc/Vmovetoolbar.png</file>
-    <file>rc/left_arrow.png</file>
-    <file>rc/stylesheet-branch-more.png</file>
-    <file>rc/up_arrow.png</file>
-    <file>rc/right_arrow.png</file>
-    <file>rc/left_arrow_disabled.png</file>
-    <file>rc/Hsepartoolbar.png</file>
-    <file>rc/branch_open.png</file>
-    <file>rc/Vsepartoolbar.png</file>
     <file>rc/down_arrow_disabled.png</file>
-    <file>rc/undock.png</file>
-    <file>rc/checkbox_checked_disabled.png</file>
-    <file>rc/checkbox_checked_focus.png</file>
-    <file>rc/checkbox_checked.png</file>
-    <file>rc/checkbox_indeterminate.png</file>
-    <file>rc/checkbox_indeterminate_focus.png</file>
-    <file>rc/checkbox_unchecked_disabled.png</file>
-    <file>rc/checkbox_unchecked_focus.png</file>
-    <file>rc/checkbox_unchecked.png</file>
-    <file>rc/radio_checked_disabled.png</file>
-    <file>rc/radio_checked_focus.png</file>
+    <file>rc/left_arrow.png</file>
+    <file>rc/left_arrow_disabled.png</file>
     <file>rc/radio_checked.png</file>
-    <file>rc/radio_unchecked_disabled.png</file>
-    <file>rc/radio_unchecked_focus.png</file>
+    <file>rc/radio_checked@2x.png</file>
+    <file>rc/radio_checked_disabled.png</file>
+    <file>rc/radio_checked_disabled@2x.png</file>
+    <file>rc/radio_checked_focus.png</file>
+    <file>rc/radio_checked_focus@2x.png</file>
     <file>rc/radio_unchecked.png</file>
+    <file>rc/radio_unchecked@2x.png</file>
+    <file>rc/radio_unchecked_disabled.png</file>
+    <file>rc/radio_unchecked_disabled@2x.png</file>
+    <file>rc/radio_unchecked_focus.png</file>
+    <file>rc/radio_unchecked_focus@2x.png</file>
+    <file>rc/right_arrow.png</file>
+    <file>rc/right_arrow_disabled.png</file>
+    <file>rc/sizegrip.png</file>
+    <file>rc/stylesheet-branch-end.png</file>
+    <file>rc/stylesheet-branch-more.png</file>
+    <file>rc/stylesheet-vline.png</file>
+    <file>rc/transparent.png</file>
+    <file>rc/undock.png</file>
+    <file>rc/up_arrow.png</file>
+    <file>rc/up_arrow_disabled.png</file>
   </qresource>
   <qresource prefix="qdarkstyle">
       <file>style.qss</file>

--- a/qdarkstyle/style.qss
+++ b/qdarkstyle/style.qss
@@ -681,9 +681,10 @@ https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qsizegrip
 
 --------------------------------------------------------------------------- */
 QSizeGrip {
-  image: url(":/qss_icons/rc/sizegrip.png");
+  background: transparent;
   width: 12px;
   height: 12px;
+  image: url(":/qss_icons/rc/sizegrip.png");
 }
 
 /* QStackedWidget ---------------------------------------------------------

--- a/script/process_qrc.py
+++ b/script/process_qrc.py
@@ -42,6 +42,7 @@ from qdarkstyle.utils import create_qss
 # Constants
 HERE = os.path.abspath(os.path.dirname(__file__))
 REPO_ROOT = os.path.dirname(HERE)
+RC_PATH = os.path.join(REPO_ROOT, 'qdarkstyle', 'rc')
 
 
 class QSSFileHandler(FileSystemEventHandler):
@@ -95,6 +96,9 @@ def main(arguments):
 
 def run_process(args):
     """Process qrc files."""
+    # Generate qrc file based on the content of the resources folder
+    generate_qrc_file()
+
     print('Changing directory to: ', args.qrc_dir)
     os.chdir(args.qrc_dir)
 
@@ -170,6 +174,35 @@ def run_process(args):
             with open(py_file_pyqtgraph, 'w+') as file:
                 # write the file out again
                 file.write(filedata)
+
+
+def generate_qrc_file(resource_prefix='qss_icons', style_prefix='qdarkstyle'):
+    """Help."""
+
+    template_header = '''<RCC>
+  <qresource prefix="{resource_prefix}">
+'''
+    template_footer = '''
+  </qresource>
+  <qresource prefix="{style_prefix}">
+      <file>style.qss</file>
+  </qresource>
+</RCC>
+'''
+    template_file = '    <file>rc/{fname}</file>'
+    files = []
+    for fname in sorted(os.listdir(RC_PATH)):
+        files.append(template_file.format(fname=fname))
+
+    # Join parts
+    qrc_content = (template_header.format(resource_prefix=resource_prefix)
+                   + '\n'.join(files)
+                   + template_footer.format(style_prefix=style_prefix))
+
+    # Write qrc file
+    qrc_path = os.path.join(REPO_ROOT, 'qdarkstyle', 'style.qrc')
+    with open(qrc_path, 'w') as fh:
+        fh.write(qrc_content)
 
 
 if __name__ == '__main__':

--- a/script/process_qrc.py
+++ b/script/process_qrc.py
@@ -97,6 +97,7 @@ def main(arguments):
 def run_process(args):
     """Process qrc files."""
     # Generate qrc file based on the content of the resources folder
+    print('Generating style.qrc files ...')
     generate_qrc_file()
 
     print('Changing directory to: ', args.qrc_dir)
@@ -177,8 +178,7 @@ def run_process(args):
 
 
 def generate_qrc_file(resource_prefix='qss_icons', style_prefix='qdarkstyle'):
-    """Help."""
-
+    """Generate the style.qrc file programmaticaly."""
     template_header = '''<RCC>
   <qresource prefix="{resource_prefix}">
 '''

--- a/script/run_ui_css_edition.py
+++ b/script/run_ui_css_edition.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""Process qrc and ui files, then run example in while loop."""
+"""
+Process qrc, ui, image, and screenshot files, then run example in while loop.
+"""
 
 # Standard library imports
 from __future__ import absolute_import, print_function
@@ -17,38 +19,41 @@ def main():
     """Process qrc and ui files, then run example in while loop."""
     dark = None
     no_dark = None
-
+    themes = {'Dark': dark, 'No Dark': no_dark}
     while True:
-        try:
-            dark.kill()
-        except AttributeError:
-            print('Dark not running!')
-        except Exception:
-            print('Dark still running!')
-        else:
-            print('Dark was killed!')
-
-        try:
-            no_dark.kill()
-        except AttributeError:
-            print('No Dark not running!')
-        except Exception:
-            print('No Dark still running!')
-        else:
-            print('No Dark was killed!')
+        for theme_name, theme_process in themes.items():
+            try:
+                theme_process.kill()
+            except AttributeError:
+                print(theme_name + ' not running!')
+            except Exception:
+                print(theme_name + ' still running!')
+            else:
+                print(theme_name + ' was killed!')
 
         print(sys.argv)
 
-        # process qrc files
+        # Process images
+        process_images = os.path.join(HERE, 'process_images.py')
+        call(['python', process_images])
+
+        # Process qrc files
         process_qrc = os.path.join(HERE, 'process_qrc.py')
         call(['python', process_qrc])
-        # process ui files
+
+        # Process ui files
         process_ui = os.path.join(HERE, 'process_ui.py')
         call(['python', process_ui])
-        # open dark example
+
+        # Create screenshots
         example = os.path.join(REPO_ROOT, 'example', 'example.py')
+        call(['python', example, '--screenshots'])
+        call(['python', example, '--no_dark', '--screenshots'])
+
+        # Open dark example
         dark = call(['python', example] + sys.argv[1:])
-        # open no dark example
+
+        # Open no dark example
         no_dark = call(['python', example, '--no_dark'] + sys.argv[1:])
 
         if dark or no_dark:


### PR DESCRIPTION
This PR provides several small fixes:

- [x] Creates the `style.qrc` file programmatically to include the latest retina images
- [x] Fixes the sizegrip style after the status bar was changed
- [x] Clean up the code of the `run_ui_css_edition.py` script and include the screenshot generation step

---

Now the radio buttons (and other widgets) look crisp on retina displays :-)

<img width="1040" alt="Screen Shot 2019-05-04 at 11 57 32" src="https://user-images.githubusercontent.com/3627835/57182364-d40dc280-6e63-11e9-9ffd-acaaf086d475.png">


