### PR TITLE
PR: Fix cropped text on dock tabbars for top and bottom position

### DIFF
--- a/qdarkstyle/qss/_styles.scss
+++ b/qdarkstyle/qss/_styles.scss
@@ -1578,7 +1578,10 @@ QTabBar {
             &:!selected:hover {
                 border: $BORDER_SELECTION_LIGHT;
                 border-bottom: 3px solid $COLOR_SELECTION_LIGHT;
-                padding: 0px;
+
+                /* Fixes spyder-ide/spyder#9766 */
+                padding-left: 4px;
+                padding-right: 4px;
             }
         }
 
@@ -1606,7 +1609,10 @@ QTabBar {
             &:!selected:hover {
                 border: $BORDER_SELECTION_LIGHT;
                 border-top: 3px solid $COLOR_SELECTION_LIGHT;
-                padding: 0px;
+
+                /* Fixes spyder-ide/spyder#9766 */
+                padding-left: 4px;
+                padding-right: 4px;
             }
 
         }

--- a/qdarkstyle/style.qss
+++ b/qdarkstyle/style.qss
@@ -1,6 +1,6 @@
 /* ---------------------------------------------------------------------------
 
-    Created by the qtsass compiler v0.1.1
+    Created by the qtsass compiler v0.1.2.dev0
 
     The definitions are in the "qdarkstyle.qss._styles.scss" module
 
@@ -1524,7 +1524,9 @@ QTabBar::tab:top:selected {
 QTabBar::tab:top:!selected:hover {
   border: 1px solid #148CD2;
   border-bottom: 3px solid #148CD2;
-  padding: 0px;
+  /* Fixes spyder-ide/spyder#9766 */
+  padding-left: 4px;
+  padding-right: 4px;
 }
 
 QTabBar::tab:bottom {
@@ -1552,7 +1554,9 @@ QTabBar::tab:bottom:selected {
 QTabBar::tab:bottom:!selected:hover {
   border: 1px solid #148CD2;
   border-top: 3px solid #148CD2;
-  padding: 0px;
+  /* Fixes spyder-ide/spyder#9766 */
+  padding-left: 4px;
+  padding-right: 4px;
 }
 
 QTabBar::tab:left {


### PR DESCRIPTION
Fixes #199
Fixes spyder-ide/spyder#9766

![tab](https://user-images.githubusercontent.com/3627835/60771984-eea72680-a0b4-11e9-86c0-8807089c2e74.gif)


