### PR TITLE
Fix QGroupBox indicator displayed incorrectly when unfocused

### DIFF
--- a/qdarkstyle/qss/_styles.scss
+++ b/qdarkstyle/qss/_styles.scss
@@ -226,6 +226,8 @@ QGroupBox {
         width: 12px;
 
         &:unchecked {
+            border: none;
+            image: url($PATH_RESOURCES + '/rc/checkbox_unchecked.png');
 
             &:hover,
             &:focus,
@@ -240,6 +242,8 @@ QGroupBox {
         }
 
         &:checked {
+            border: none;
+            image: url($PATH_RESOURCES + '/rc/checkbox_checked.png');
 
             &:hover,
             &:focus,


### PR DESCRIPTION
Fixes #219
Before:
![before](https://user-images.githubusercontent.com/60840213/75491134-79cb8880-59c6-11ea-9b75-f4045b74c570.png)
After applying the fix:
![after](https://user-images.githubusercontent.com/60840213/75491141-7f28d300-59c6-11ea-806d-ba7d58d81fbc.png)
Still, the size is different, but that's another issue which is to be fixed yet.
