### PR TITLE
Fix incorrect size of QGroupBox indicator

### DIFF
--- a/qdarkstyle/qss/_styles.scss
+++ b/qdarkstyle/qss/_styles.scss
@@ -222,8 +222,8 @@ QGroupBox {
 
     &::indicator {
         margin-left: 2px;
-        height: 12px;
-        width: 12px;
+        height: 16px;
+        width: 16px;
 
         &:unchecked {
 


### PR DESCRIPTION
Fixes #218
Before:
![before](https://user-images.githubusercontent.com/60840213/75493253-84881c80-59ca-11ea-8d9e-e2a338008591.png)
After applying the fix (including #222):
![after](https://user-images.githubusercontent.com/60840213/75493310-a8e3f900-59ca-11ea-8630-91835b2b45b0.png)
The size of the groupbox's indicator is now the same as that of normal checkbox.