### PR TITLE
Fix QDateTimeEdit dropdown in calendar mode

### DIFF
--- a/qdarkstyle/qss/_styles.scss
+++ b/qdarkstyle/qss/_styles.scss
@@ -2174,10 +2174,10 @@ QSplitter {
     }
 }
 
-/* QDateEdit --------------------------------------------------------------
+/* QDateEdit, QDateTimeEdit -----------------------------------------------
 
 --------------------------------------------------------------------------- */
-QDateEdit {
+QDateEdit, QDateTimeEdit {
     selection-background-color: $COLOR_SELECTION_NORMAL;
     border-style: solid;
     border: $BORDER_NORMAL;


### PR DESCRIPTION
Fixes #220
Before:
![before](https://user-images.githubusercontent.com/60840213/75495174-f3677480-59ce-11ea-96f1-e711a14be379.png)
After applying the fix:
![after](https://user-images.githubusercontent.com/60840213/75495268-2e69a800-59cf-11ea-8053-de6ece7b2d6a.png)
QDateTimeEdit's dropdown now looks the same as dropdown for QDateEdit and QComboBox.

PS. If I only knew all the fixes were basically one-liners I would put all of them in single PR!  :alien: