### PR TITLE
Fixed incorrect QGroupBox indicator and QDateTimeEdit drop-down

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -27,5 +27,6 @@ insert your information after the last one.
 -  2018 - Xingyun Wu - ``xingyun.wu@foxmail.com`` - bug fixes.
 -  2018 - `KcHNST <https://github.com/KcHNST>`__ - bug fixes.
 -  2019 - `goanpeca <https://github.com/goanpeca>`__ - bug fixes, improvements, features.
+-  2020 - `tsilia <https://github.com/tsilia>`__ - bug fixes.
 
 And all people that reported bugs, thank you all!

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,9 @@
 Changelog
 =========
+-  2.8.1:
+    -  Fix QGroupBox small indicator size #218
+    -  Fix QGroupBox incorrect indicator icon when unfocused #219
+    -  Fix QDateTimeEdit incorrect drop-down arrow icon #220
 -  2.8:
     -  Fix tooltip giant rectangle #174
     -  Fix QTextEdit wihout borders inside frame #188

--- a/qdarkstyle/qss/_styles.scss
+++ b/qdarkstyle/qss/_styles.scss
@@ -222,10 +222,12 @@ QGroupBox {
 
     &::indicator {
         margin-left: 2px;
-        height: 12px;
-        width: 12px;
+        height: 16px;
+        width: 16px;
 
         &:unchecked {
+            border: none;
+            image: url($PATH_RESOURCES + '/rc/checkbox_unchecked.png');
 
             &:hover,
             &:focus,
@@ -240,6 +242,9 @@ QGroupBox {
         }
 
         &:checked {
+            border: none;
+            image: url($PATH_RESOURCES + '/rc/checkbox_checked.png');
+
 
             &:hover,
             &:focus,
@@ -2174,10 +2179,10 @@ QSplitter {
     }
 }
 
-/* QDateEdit --------------------------------------------------------------
+/* QDateEdit, QDateTimeEdit -----------------------------------------------
 
 --------------------------------------------------------------------------- */
-QDateEdit {
+QDateEdit, QDateTimeEdit {
     selection-background-color: $COLOR_SELECTION_NORMAL;
     border-style: solid;
     border: $BORDER_NORMAL;


### PR DESCRIPTION
This commit fixes #218, #219, #220.

Before:
![before](https://user-images.githubusercontent.com/60840213/75712057-65460380-5cd8-11ea-93e4-9b3846edff2d.png)
After:
![after](https://user-images.githubusercontent.com/60840213/75712064-67a85d80-5cd8-11ea-87f9-04665d4f9ab4.png)
The size and icon of the groupbox's indicator are now the same as those of normal checkbox.
QDateTimeEdit's dropdown now looks the same as dropdown for QDateEdit and QComboBox.
