### PR TITLE
Fixed syntax error in deprecated code

### DIFF
--- a/qdarkstyle/__init__.py
+++ b/qdarkstyle/__init__.py
@@ -385,7 +385,7 @@ def load_stylesheet_from_environment(is_pyqtgraph=False):
     warnings.warn(DEPRECATION_MSG, DeprecationWarning)
 
     if is_pyqtgraph:
-        stylesheet = _load_stylesheet(qt_api=os.environ('PYQTGRAPH_QT_LIB'))
+        stylesheet = _load_stylesheet(qt_api=os.environ.get('PYQTGRAPH_QT_LIB', None))
     else:
         stylesheet = _load_stylesheet()
 


### PR DESCRIPTION
```
In [7]: qdarkstyle.load_stylesheet_from_environment(is_pyqtgraph=True)
Traceback (most recent call last):

  File "<ipython-input-7-7235cbc7ab37>", line 1, in <module>
    qdarkstyle.load_stylesheet_from_environment(is_pyqtgraph=True)

  File "C:\Users\Oscar\Anaconda3\lib\site-packages\qdarkstyle\__init__.py", line 388, in load_stylesheet_from_environment
    stylesheet = _load_stylesheet(qt_api=os.environ('PYQTGRAPH_QT_LIB'))

TypeError: '_Environ' object is not callable
```
Deprecated, but still good if no syntax errors occur...