### PR TITLE
Change checkboxes to checkmark instead of fill

### DIFF
--- a/qdarkstyle/svg/checkbox_checked.svg
+++ b/qdarkstyle/svg/checkbox_checked.svg
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -9,90 +7,49 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="32"
-   height="32"
-   viewBox="0 0 32 32.000001"
-   id="svg2"
    version="1.1"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
-   inkscape:export-filename="/home/colin/checkbox_checked.png"
-   inkscape:export-xdpi="90"
-   inkscape:export-ydpi="90"
-   sodipodi:docname="checkbox_checked.svg">
-  <defs
-     id="defs4" />
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="11.313708"
-     inkscape:cx="15.849054"
-     inkscape:cy="18.479682"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer1"
-     showgrid="true"
-     units="px"
-     inkscape:window-width="1366"
-     inkscape:window-height="705"
-     inkscape:window-x="-8"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     showguides="true"
-     inkscape:guide-bbox="true">
-    <inkscape:grid
-       type="xygrid"
-       id="grid4203" />
-    <sodipodi:guide
-       position="-15,16"
-       orientation="0,1"
-       id="guide4205"
-       inkscape:locked="false" />
-    <sodipodi:guide
-       position="16,22.000001"
-       orientation="1,0"
-       id="guide4207"
-       inkscape:locked="false" />
-  </sodipodi:namedview>
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   id="svg901"
+   sodipodi:docname="checkbox_checked.svg"
+   inkscape:version="1.0.2 (e86c8708, 2021-01-15)">
   <metadata
-     id="metadata7">
+     id="metadata907">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
-     id="layer1"
-     transform="translate(0,-1020.3622)">
-    <rect
-       style="opacity:1;fill:#000000;fill-opacity:0;fill-rule:evenodd;stroke:#ff0000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="rect3338"
-       width="26"
-       height="26"
-       x="3"
-       y="1023.3622"
-       ry="4"
-       inkscape:export-xdpi="90"
-       inkscape:export-ydpi="90" />
-    <rect
-       inkscape:export-xdpi="90"
-       inkscape:export-ydpi="90"
-       style="opacity:1;fill:#ff0000;fill-opacity:1;stroke:#ff0000;stroke-width:1.29718304;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="rect4159"
-       width="14.702817"
-       height="14.702817"
-       x="8.648592"
-       y="1029.0107"
-       rx="0"
-       ry="2" />
-  </g>
+  <defs
+     id="defs905" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="800"
+     id="namedview903"
+     showgrid="false"
+     inkscape:zoom="23.708333"
+     inkscape:cx="3.8804921"
+     inkscape:cy="12"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg901" />
+  <path
+     d="M19,19H5V5H15V3H5C3.89,3 3,3.89 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V11H19M7.91,10.08L6.5,11.5L11,16L21,6L19.59,4.58L11,13.17L7.91,10.08Z"
+     id="path899"
+     style="fill:#ff0000;fill-opacity:1" />
 </svg>


### PR DESCRIPTION
We discussed with @isabela-pf and @ccordoba12 about the checkboxes and they look a bit confusing when they are filled because they look more like buttons. For this reason we decided to switch the check state to a checkmark. https://github.com/spyder-ide/ux-improvements/issues/1

Here is a screenshot of how it looks in Spyder

<img width="1280" alt="Screenshot 2021-01-22 at 11 29 10 AM" src="https://user-images.githubusercontent.com/18587879/105520042-2b8f3a00-5ca8-11eb-89fd-68bd3a99ce82.png">