### PR TITLE
Remove blue outline for hover in panes and add focus to QColumnView

### DIFF
--- a/qdarkstyle/qss/_styles.scss
+++ b/qdarkstyle/qss/_styles.scss
@@ -673,11 +673,6 @@ QTextEdit {
     border-radius: $SIZE_BORDER_RADIUS;
     border: $BORDER_NORMAL;
 
-    &:hover {
-        border: $BORDER_SELECTION_LIGHT;
-        color: $COLOR_FOREGROUND_LIGHT;
-    }
-
     &:focus {
         border: $BORDER_SELECTION_NORMAL;
     }
@@ -696,11 +691,6 @@ QPlainTextEdit {
     color: $COLOR_FOREGROUND_LIGHT;
     border-radius: $SIZE_BORDER_RADIUS;
     border: $BORDER_NORMAL;
-
-    &:hover {
-        border: $BORDER_SELECTION_LIGHT;
-        color: $COLOR_FOREGROUND_LIGHT;
-    }
 
     &:focus {
         border: $BORDER_SELECTION_NORMAL;
@@ -1923,9 +1913,8 @@ QColumnView {
         color: $COLOR_BACKGROUND_NORMAL;
     }
 
-    &:hover {
-        background-color: $COLOR_BACKGROUND_DARK;
-        border: $BORDER_SELECTION_LIGHT;
+    &:focus {
+        border: $BORDER_SELECTION_NORMAL;
     }
 
     &::item {


### PR DESCRIPTION
As stated in https://github.com/spyder-ide/ux-improvements/issues/27 we discussed with @ccordoba12 and @isabela-pf about removing the blue outline for the hover state of the panes because it is confusing to have both (the hovering and the focus one). 

This PR removes the hovering for the QTextEdit, QPlainTextEdit and QColumnView corresponding to the Editor, Console and the panes in the upper right corner in Spyder. It also adds the focus state to the QColumnView since it currently doesn't have it so the panes at the upper right corner don't have the blue outline when focused.

In the following gif we can see the behaviour for spyder with this PR:

![hover](https://user-images.githubusercontent.com/18587879/106506628-f8af2800-6497-11eb-9d2f-0110283a0267.gif)

Please @dpizetta let us know if this change is possible.
