### PR TITLE
Remove combo checked item boldness to prevent bug on qt5.15

### DIFF
--- a/qdarkstyle/dark/style.qss
+++ b/qdarkstyle/dark/style.qss
@@ -1290,10 +1290,6 @@ QComboBox::item:alternate {
   background: #19232D;
 }
 
-QComboBox::item:checked {
-  font-weight: bold;
-}
-
 QComboBox::item:selected {
   border: 0px solid transparent;
 }

--- a/qdarkstyle/light/style.qss
+++ b/qdarkstyle/light/style.qss
@@ -1290,10 +1290,6 @@ QComboBox::item:alternate {
   background: #FAFAFA;
 }
 
-QComboBox::item:checked {
-  font-weight: bold;
-}
-
 QComboBox::item:selected {
   border: 0px solid transparent;
 }


### PR DESCRIPTION
This is not a fix to #285 because it remove the capacity to see the current selected item in bold but it at least remove the annoying bug.