### PR TITLE
Fix deprecation warning

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,7 +1,7 @@
 Authors
 =======
 
-Mainteiner(s)
+Maintainer(s)
 -------------
 
 These people were/are mainteiners of this project.
@@ -31,5 +31,6 @@ insert your information after the last one.
 -  2021 - `isabela-pf <https://github.com/isabela-pf>`__ - new palette design.
 -  2021 - `juanis2112 <https://github.com/juanis2112>`__ - improvements.
 -  2021 - `ccordoba12 <https://github.com/ccordoba12>`__ - mainteiner/improvements.
+-  2021 - Julian Gilbey ``jdg@debian.org`` - bug fixes.
 
 And all people that reported bugs, thank you all!

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,12 +1,14 @@
 Changelog
 =========
 
+- 3.0.4:
+    - Fix global variables issue #298
+    - Include data files when installing package #299
 - 3.0.3:
     - Temporary fix for expanded combo box in Qt 5.15, fixes #282, #285, MR #288
     - Fix generating assets in Posix
     - Fix tristate value for checkbox #275
     - Minor fixes and improvements
-    - Include data files when installing package #299
 - 3.0.2:
     - Enable the use of setTabColor and add example, fixes #212
     - Update description to inform about Python 2 and Qt4 unsupported versions

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
     - Fix generating assets in Posix
     - Fix tristate value for checkbox #275
     - Minor fixes and improvements
+    - Include data files when installing package #299
 - 3.0.2:
     - Enable the use of setTabColor and add example, fixes #212
     - Update description to inform about Python 2 and Qt4 unsupported versions

--- a/qdarkstyle/__init__.py
+++ b/qdarkstyle/__init__.py
@@ -75,31 +75,41 @@ __version__ = "3.0.3"
 _logger = logging.getLogger(__name__)
 
 # Folder's path
-REPO_PATH = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
+def _set_global_paths(palette='dark'):
+    global REPO_PATH
+    REPO_PATH = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
 
-EXAMPLE_PATH = os.path.join(REPO_PATH, 'example')
-IMAGES_PATH = os.path.join(REPO_PATH, 'docs/images')
-PACKAGE_PATH = os.path.join(REPO_PATH, 'qdarkstyle')
+    global EXAMPLE_PATH, IMAGES_PATH, PACKAGE_PATH
+    EXAMPLE_PATH = os.path.join(REPO_PATH, 'example')
+    IMAGES_PATH = os.path.join(REPO_PATH, 'docs/images')
+    PACKAGE_PATH = os.path.join(REPO_PATH, 'qdarkstyle')
 
-QSS_PATH = os.path.join(PACKAGE_PATH, 'qss')
-RC_PATH = os.path.join(PACKAGE_PATH, 'rc')
-SVG_PATH = os.path.join(PACKAGE_PATH, 'svg')
+    global QSS_PATH, RC_PATH, SVG_PATH
+    QSS_PATH = os.path.join(PACKAGE_PATH, 'qss')
+    RC_PATH = os.path.join(PACKAGE_PATH, palette, 'rc')
+    SVG_PATH = os.path.join(PACKAGE_PATH, 'svg')
 
-# File names
-QSS_FILE = 'style.qss'
-QRC_FILE = QSS_FILE.replace('.qss', '.qrc')
+    # File names
+    global QSS_FILE, QRC_FILE
+    QSS_FILE = 'style.qss'
+    QRC_FILE = QSS_FILE.replace('.qss', '.qrc')
 
-MAIN_SCSS_FILE = 'main.scss'
-STYLES_SCSS_FILE = '_styles.scss'
-VARIABLES_SCSS_FILE = '_variables.scss'
+    global MAIN_SCSS_FILE, STYLES_SCSS_FILE, VARIABLES_SCSS_FILE
+    MAIN_SCSS_FILE = 'main.scss'
+    STYLES_SCSS_FILE = '_styles.scss'
+    VARIABLES_SCSS_FILE = '_variables.scss'
 
-# File paths
-QSS_FILEPATH = os.path.join(PACKAGE_PATH, QSS_FILE)
-QRC_FILEPATH = os.path.join(PACKAGE_PATH, QRC_FILE)
+    # File paths
+    global QSS_FILEPATH, QRC_FILEPATH
+    QSS_FILEPATH = os.path.join(PACKAGE_PATH, palette, QSS_FILE)
+    QRC_FILEPATH = os.path.join(PACKAGE_PATH, palette, QRC_FILE)
 
-MAIN_SCSS_FILEPATH = os.path.join(QSS_PATH, MAIN_SCSS_FILE)
-STYLES_SCSS_FILEPATH = os.path.join(QSS_PATH, STYLES_SCSS_FILE)
-VARIABLES_SCSS_FILEPATH = os.path.join(QSS_PATH, VARIABLES_SCSS_FILE)
+    global MAIN_SCSS_FILEPATH, STYLES_SCSS_FILEPATH, VARIABLES_SCSS_FILEPATH
+    MAIN_SCSS_FILEPATH = os.path.join(QSS_PATH, palette, MAIN_SCSS_FILE)
+    STYLES_SCSS_FILEPATH = os.path.join(QSS_PATH, STYLES_SCSS_FILE)
+    VARIABLES_SCSS_FILEPATH = os.path.join(QSS_PATH, palette, VARIABLES_SCSS_FILE)
+
+_set_global_paths()
 
 # Todo: check if we are deprecate all those functions or keep them
 DEPRECATION_MSG = '''This function will be deprecated in v3.0.
@@ -249,12 +259,15 @@ def _load_stylesheet(qt_api='', palette=None):
     if palette is None:
         from qdarkstyle.dark import style_rc
         palette = DarkPalette
+        _set_global_paths('dark')
     elif palette.ID == 'dark':
         from qdarkstyle.dark import style_rc
         palette = DarkPalette
+        _set_global_paths('dark')
     elif palette.ID == 'light':
         from qdarkstyle.light import style_rc
         palette = LightPalette
+        _set_global_paths('light')
     else:
         print("Not recognized ID for palette! Exiting!")
         sys.exit(1)

--- a/qdarkstyle/__init__.py
+++ b/qdarkstyle/__init__.py
@@ -214,10 +214,10 @@ def _apply_application_patches(QCoreApplication, QPalette, QColor, palette):
         app_palette.setColor(QPalette.Normal, QPalette.Link, qcolor)
         app.setPalette(app_palette)
     else:
-        _logger.warn("No QCoreApplication instance found. "
-                     "Application patches not applied. "
-                     "You have to call load_stylesheet function after "
-                     "instantiation of QApplication to take effect. ")
+        _logger.warning("No QCoreApplication instance found. "
+                        "Application patches not applied. "
+                        "You have to call load_stylesheet function after "
+                        "instantiation of QApplication to take effect. ")
 
 
 def _load_stylesheet(qt_api='', palette=None):

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,14 @@ setup(
     long_description=long_desc,
     long_description_content_type='text/x-rst',
     include_package_data=True,  # add data file from MANIFEST.in #193
+    package_data={  # add data files when installing package #299
+        "": ["*",
+             "dark/rc/*",
+             "light/rc/*",
+             "qss/*",
+             "svg/*",
+             ],
+    },
     classifiers=classifiers,
     zip_safe=False,  # don't use eggs
     entry_points={"console_scripts": ["qdarkstyle=qdarkstyle.__main__:main",


### PR DESCRIPTION
According to https://docs.python.org/3/library/logging.html#logging.Logger.warning the `warn()` method is deprecated, and it is now giving deprecation warnings.  The equivalent `warning()` method has been present since at least Python 3.5.  This patch replaces `warn()` with `warning()`.