### PR TITLE
Fix logging module DeprecationWarning

### DIFF
--- a/qdarkstyle/__init__.py
+++ b/qdarkstyle/__init__.py
@@ -214,10 +214,10 @@ def _apply_application_patches(QCoreApplication, QPalette, QColor, palette):
         app_palette.setColor(QPalette.Normal, QPalette.Link, qcolor)
         app.setPalette(app_palette)
     else:
-        _logger.warn("No QCoreApplication instance found. "
-                     "Application patches not applied. "
-                     "You have to call load_stylesheet function after "
-                     "instantiation of QApplication to take effect. ")
+        _logger.warning("No QCoreApplication instance found. "
+                        "Application patches not applied. "
+                        "You have to call load_stylesheet function after "
+                        "instantiation of QApplication to take effect. ")
 
 
 def _load_stylesheet(qt_api='', palette=None):


### PR DESCRIPTION
According to https://docs.python.org/3/library/logging.html#logging.Logger.warning the `warn()` method is deprecated, and it is now giving deprecation warnings. The equivalent `warning()` method has been present since at least Python 3.5. This patch replaces `warn()` with `warning()`.