### PR TITLE
Fix hidden background of widgets in QToolBox

### DIFF
--- a/qdarkstyle/qss/_styles.scss
+++ b/qdarkstyle/qss/_styles.scss
@@ -2168,7 +2168,7 @@ QToolBox {
         }
     }
 
-    QScrollArea QWidget QWidget {
+    QScrollArea {
         padding: 0px;
         border: 0px;
         background-color: $COLOR_BACKGROUND_1;


### PR DESCRIPTION
It seems that the background of widgets placed in QToolBox is hidden for dark and light themes:

![Bug_backround_widgets_in_qtoolbox](https://user-images.githubusercontent.com/114391430/203498449-db256fe4-8c67-4907-9f57-742cbacaeaf3.png)
![Bug_light_backround_widgets_in_qtoolbox](https://user-images.githubusercontent.com/114391430/203498452-14fa3a49-e7c6-4976-8060-42cc5f78d38e.png)

After modification:

![Fix_backround_widgets_in_qtoolbox](https://user-images.githubusercontent.com/114391430/203498466-a4f1e700-5878-416b-a5d9-2032b677d333.png)
![Fix_light_backround_widgets_in_qtoolbox](https://user-images.githubusercontent.com/114391430/203498473-fe9dff2d-02d2-4aa4-8cf6-f2d74fcda275.png)