### PR TITLE
Replace deprecated dash-separated description-file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,4 @@
 universal = 1
 
 [metadata]
-description-file = README.rst
+description_file = README.rst


### PR DESCRIPTION
Use `description_file` instead. Fixes a `SetuptoolsDeprecationWarning`; fixes #340.