### PR TITLE
Check for instance of QApplication before creating on in images util

### DIFF
--- a/qdarkstyle/utils/images.py
+++ b/qdarkstyle/utils/images.py
@@ -97,7 +97,8 @@ def create_palette_image(base_svg_path=SVG_PATH, path=IMAGES_PATH,
     Create palette image svg and png image on specified path.
     """
     # Needed to use QPixmap
-    _ = QApplication([])
+    if not QApplication.instance():
+        _ = QApplication([])
 
     if palette is None:
         _logger.error("Please pass a palette class in order to create its "
@@ -147,7 +148,8 @@ def create_images(base_svg_path=SVG_PATH, rc_path=None, palette=None):
     """
 
     # Needed to use QPixmap
-    _ = QApplication([])
+    if not QApplication.instance():
+        _ = QApplication([])
 
     if palette is None:
         _logger.error("Please pass a palette class in order to create its "


### PR DESCRIPTION
```
python scripts/run_ui_css_edition.py
```

```
-- PROCESSING THEME: dark
-- GENERATING PALETTE IMAGE FOR: dark
qt.qpa.plugin: Could not find the Qt platform plugin "wayland" in ""
INFO:qdarkstyle.utils.images:Creating palette image ...
INFO:qdarkstyle.utils.images:Base SVG: /home/mark/git/QDarkStyleSheet/qdarkstyle/svg/base_palette.svg
INFO:qdarkstyle.utils.images:To SVG: /home/mark/git/QDarkStyleSheet/docs/images/dark/palette.svg
INFO:qdarkstyle.utils.images:To PNG: /home/mark/git/QDarkStyleSheet/docs/images/dark/palette.png
-- GENERATING IMAGE FILES (.svg > .png) FOR: dark
Traceback (most recent call last):
  File "/home/mark/git/QDarkStyleSheet/scripts/../qdarkstyle/utils/__main__.py", line 96, in <module>
    sys.exit(main())
  File "/home/mark/git/QDarkStyleSheet/scripts/../qdarkstyle/utils/__main__.py", line 91, in main
    process_palette(palette=palette, compile_for=args.create)
  File "/home/mark/git/QDarkStyleSheet/qdarkstyle/utils/__init__.py", line 64, in process_palette
    create_images(palette=palette)
  File "/home/mark/git/QDarkStyleSheet/qdarkstyle/utils/images.py", line 150, in create_images
    _ = QApplication([])
RuntimeError: Please destroy the QApplication singleton before creating a new QApplication instance.

```