### PR TITLE
Drop PySide2 dependency from the example in Python 3.12+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ install_requires = ['qtpy>=2']
 extras_require = {
     'develop': ['qtsass', 'watchdog'],
     'docs': ['sphinx', 'sphinx_rtd_theme'],
-    'example': ['pyqt5', 'pyside2']
+    'example': ['pyqt5', 'pyside2; python_version<"3.12"']
 }
 
 classifiers = [


### PR DESCRIPTION
PySide2 was never adjusted to work with Python 3.12 and later; all effort went into PySide6 instead.

Unless I misunderstand, since 1c5be2e296e643ca47ec7450f17264ffb4d00251 it seems like the example defaults to `pyqt5` anyway. Maybe it would be better to drop `pyside2` unconditionally rather than conditionalizing it on the Python interpreter version? Let me know and I can amend the PR.